### PR TITLE
Add shellcheck tests and Travis config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+language: bash
+addons:
+  apt:
+    sources:
+    # Grab shellcheck from the Debian repo.
+    # https://github.com/koalaman/shellcheck/wiki/TravisCI
+    - debian-sid
+    packages:
+    - shellcheck
+script: ./travis.sh
+branches:
+  only:
+  - master
+

--- a/travis.sh
+++ b/travis.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+set -x
+shopt -s globstar
+
+# Check that all shell scripts in this repo (including this one) pass the
+# Shell Check linter.
+shellcheck ./**/*.sh

--- a/zone_failure/failure.sh
+++ b/zone_failure/failure.sh
@@ -31,7 +31,7 @@ INSTANCE_NAME=$(hostname)
 STATE="healthy"
 while true; do
   if [[ "$ZONE" = "$(GetMetadata $PROJECT_METADATA_URL/failed_zone)" ]] && \
-     [[ "$INSTANCE_NAME" =~ "$(GetMetadata $PROJECT_METADATA_URL/failed_instance_names)" ]]; then
+     [[ "$INSTANCE_NAME" = *"$(GetMetadata $PROJECT_METADATA_URL/failed_instance_names)"* ]]; then
     if [[ "$STATE" = "healthy" ]]; then
       STATE="failure"
       # Do something to simulate failure here.

--- a/zone_failure/tests/test.sh
+++ b/zone_failure/tests/test.sh
@@ -39,7 +39,7 @@ echo "Run the failure.sh script in the bg"
 gcloud --project="$PROJECT" compute ssh --zone="$ZONE" "$INSTANCE_NAME" --command "sudo bash ~/failure.sh" &
 
 # Wait for IP to serve 200s
-until curl -I $IP > /dev/null 2> /dev/null
+until curl -I "$IP" > /dev/null 2> /dev/null
 do
   echo "Waiting for Apache to serve"
   sleep 2.
@@ -47,10 +47,10 @@ done
 echo "Apache is serving - INIT IS DONE"
 
 echo "Enabling failure simulation"
-gcloud --project="$PROJECT" compute project-info add-metadata --metadata failed_zone="$ZONE",failed_instance_names="$INSTANCE_NAME.*" || exit
+gcloud --project="$PROJECT" compute project-info add-metadata --metadata "failed_zone=${ZONE},failed_instance_names=${INSTANCE_NAME}.*" || exit
 
 # Wait for IP to top serving 200s
-while curl -I $IP > /dev/null 2> /dev/null
+while curl -I "$IP" > /dev/null 2> /dev/null
 do
   echo "Waiting for Apache to stop serving"
   sleep 2.
@@ -61,7 +61,7 @@ echo "Apache stoped serving - ENABLING FAILURE WAS SUCCESSFUL"
 echo "Reverting from failure simulation"
 gcloud --project="$PROJECT" compute project-info remove-metadata --keys failed_zone,failed_instance_names || exit
 
-until curl -I $IP > /dev/null 2> /dev/null
+until curl -I "$IP" > /dev/null 2> /dev/null
 do
   echo "Wating for apache to serve again"
   sleep 2.


### PR DESCRIPTION
Fixes shellcheck warnings:
- Adds double quotes in various spots to prevent word splitting.
- Removes double quotes in regex match, because they cause it to be
  interpreted as a string literal instead of regex.
