### PR TITLE
Fix and retry SSH commands in test script.

### DIFF
--- a/zone_failure/tests/post_build.sh
+++ b/zone_failure/tests/post_build.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+# Check that environment variables are set.
+if [[ -z ${PROJECT} ]] ; then
+  (>&2 echo "PROJECT environment variable must be set.")
+  exit 1
+fi
+
+if [[ -z ${INSTANCE_NAME} ]] ; then
+  (>&2 echo "INSTANCE_NAME environment variable must be set.")
+  exit 1
+fi
+
+if [[ -z ${ZONE} ]] ; then
+  (>&2 echo "ZONE environment variable must be set.")
+  exit 1
+fi
+
+echo "deleting the instance"
+gcloud --project="$PROJECT" compute instances delete "$INSTANCE_NAME" --zone="$ZONE" -q
+

--- a/zone_failure/tests/test.sh
+++ b/zone_failure/tests/test.sh
@@ -17,6 +17,7 @@
 set -o nounset
 set -o errexit
 set -o pipefail
+set -x
 
 # Check that environment variables are set.
 if [[ -z ${PROJECT} ]] ; then
@@ -50,7 +51,7 @@ echo "Got and IP: $IP"
 
 echo "Copy the failure.sh script to VM"
 for i in  {1..10} ; do
-  gcloud --project="$PROJECT" compute copy-files --zone="$ZONE" "$DIR/../failure.sh" "root@$INSTANCE_NAME:~/failure.sh" && rc=$? || rc=$?
+  gcloud --project="$PROJECT" compute copy-files --zone="$ZONE" "$DIR/../failure.sh" "testuser@$INSTANCE_NAME:~/failure.sh" && rc=$? || rc=$?
   echo "Sleeping 30 seconds"
   sleep 30
   if [[ $rc == 0 ]] ; then
@@ -65,7 +66,7 @@ done
 
 echo "Run the failure.sh script in the bg"
 for i in  {1..10} ; do
-  gcloud --project="$PROJECT" compute ssh --zone="$ZONE" "root@$INSTANCE_NAME" --command "sudo bash ~/failure.sh" &
+  gcloud --project="$PROJECT" compute ssh --zone="$ZONE" "testuser@$INSTANCE_NAME" --command "sudo bash ~/failure.sh" &
   ssh_pid=$!
   echo "Sleeping 30 seconds"
   sleep 30

--- a/zone_failure/tests/test.sh
+++ b/zone_failure/tests/test.sh
@@ -58,6 +58,8 @@ for i in  1 .. 10 ; do
     break
   elif [[ $i != 10 ]] ; then
     echo "Retrying"
+  else
+    exit 1
   fi
 done
 
@@ -73,6 +75,8 @@ for i in  1 .. 10 ; do
     break
   elif [[ $i != 10 ]] ; then
     echo "Retrying"
+  else
+    exit 1
   fi
 done
 

--- a/zone_failure/tests/test.sh
+++ b/zone_failure/tests/test.sh
@@ -50,7 +50,7 @@ echo "Got and IP: $IP"
 
 echo "Copy the failure.sh script to VM"
 for i in  {1..10} ; do
-  gcloud --project="$PROJECT" compute copy-files --zone="$ZONE" "$DIR/../failure.sh" "$INSTANCE_NAME:~/failure.sh" && rc=$? || rc=$?
+  gcloud --project="$PROJECT" compute copy-files --zone="$ZONE" "$DIR/../failure.sh" "root@$INSTANCE_NAME:~/failure.sh" && rc=$? || rc=$?
   echo "Sleeping 30 seconds"
   sleep 30
   if [[ $rc == 0 ]] ; then
@@ -65,7 +65,7 @@ done
 
 echo "Run the failure.sh script in the bg"
 for i in  {1..10} ; do
-  gcloud --project="$PROJECT" compute ssh --zone="$ZONE" "$INSTANCE_NAME" --command "sudo bash ~/failure.sh" &
+  gcloud --project="$PROJECT" compute ssh --zone="$ZONE" "root@$INSTANCE_NAME" --command "sudo bash ~/failure.sh" &
   ssh_pid=$!
   echo "Sleeping 30 seconds"
   sleep 30

--- a/zone_failure/tests/test.sh
+++ b/zone_failure/tests/test.sh
@@ -49,7 +49,7 @@ IP=$(gcloud --project="$PROJECT" compute instances describe "$INSTANCE_NAME" --z
 echo "Got and IP: $IP"
 
 echo "Copy the failure.sh script to VM"
-for i in  1 .. 10 ; do
+for i in  {1..10} ; do
   gcloud --project="$PROJECT" compute copy-files --zone="$ZONE" "$DIR/../failure.sh" "$INSTANCE_NAME:~/failure.sh" && rc=$? || rc=$?
   echo "Sleeping 30 seconds"
   sleep 30
@@ -64,7 +64,7 @@ for i in  1 .. 10 ; do
 done
 
 echo "Run the failure.sh script in the bg"
-for i in  1 .. 10 ; do
+for i in  {1..10} ; do
   gcloud --project="$PROJECT" compute ssh --zone="$ZONE" "$INSTANCE_NAME" --command "sudo bash ~/failure.sh" &
   ssh_pid=$!
   echo "Sleeping 30 seconds"

--- a/zone_failure/tests/test.sh
+++ b/zone_failure/tests/test.sh
@@ -18,9 +18,21 @@ set -o nounset
 set -o errexit
 set -o pipefail
 
-PROJECT="shell-samples"
-INSTANCE_NAME="failure-simulation"
-ZONE="us-central1-a"
+# Check that environment variables are set.
+if [[ -z ${PROJECT} ]] ; then
+  (>&2 echo "PROJECT environment variable must be set.")
+  exit 1
+fi
+
+if [[ -z ${INSTANCE_NAME} ]] ; then
+  (>&2 echo "INSTANCE_NAME environment variable must be set.")
+  exit 1
+fi
+
+if [[ -z ${ZONE} ]] ; then
+  (>&2 echo "ZONE environment variable must be set.")
+  exit 1
+fi
 
 echo "Cleanup after previous runs"
 gcloud --project="$PROJECT" compute project-info remove-metadata --keys failed_zone,failed_instance_names
@@ -47,7 +59,7 @@ done
 echo "Apache is serving - INIT IS DONE"
 
 echo "Enabling failure simulation"
-gcloud --project="$PROJECT" compute project-info add-metadata --metadata "failed_zone=${ZONE},failed_instance_names=${INSTANCE_NAME}.*" || exit
+gcloud --project="$PROJECT" compute project-info add-metadata --metadata "failed_zone=${ZONE},failed_instance_names=${INSTANCE_NAME}" || exit
 
 # Wait for IP to top serving 200s
 while curl -I "$IP" > /dev/null 2> /dev/null
@@ -69,6 +81,3 @@ done
 echo "Apache is serving - RECOVERY WAS SUCCESSFUL"
 
 echo "TEST WAS SUCCESSFUL!!!"
-
-echo "deleting the instance"
-gcloud --project="$PROJECT" compute instances delete "$INSTANCE_NAME" --zone="$ZONE" -q

--- a/zone_failure/tests/test.sh
+++ b/zone_failure/tests/test.sh
@@ -34,6 +34,10 @@ if [[ -z ${ZONE} ]] ; then
   exit 1
 fi
 
+# Get this script's directory.
+# http://stackoverflow.com/a/246128/101923
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
 echo "Cleanup after previous runs"
 gcloud --project="$PROJECT" compute project-info remove-metadata --keys failed_zone,failed_instance_names
 
@@ -46,7 +50,7 @@ echo "Got and IP: $IP"
 
 echo "Copy the failure.sh script to VM"
 for i in  1 .. 10 ; do
-  gcloud --project="$PROJECT" compute copy-files --zone="$ZONE" ../failure.sh "$INSTANCE_NAME:~/failure.sh" && rc=$? || rc=$?
+  gcloud --project="$PROJECT" compute copy-files --zone="$ZONE" "$DIR/../failure.sh" "$INSTANCE_NAME:~/failure.sh" && rc=$? || rc=$?
   echo "Sleeping 30 seconds"
   sleep 30
   if [[ $rc == 0 ]] ; then

--- a/zone_failure/tests/test.sh
+++ b/zone_failure/tests/test.sh
@@ -54,6 +54,7 @@ for i in  1 .. 10 ; do
   echo "Sleeping 30 seconds"
   sleep 30
   if [[ $rc == 0 ]] ; then
+    echo "File copied"
     break
   elif [[ $i != 10 ]] ; then
     echo "Retrying"
@@ -68,6 +69,7 @@ for i in  1 .. 10 ; do
   sleep 30
   # Check if the background process is still alive.
   if kill -0 $ssh_pid ; then
+    echo "Script started"
     break
   elif [[ $i != 10 ]] ; then
     echo "Retrying"


### PR DESCRIPTION
Fixes the instance name, now that regex is no longer used.

The copy-files and ssh commands were not succeeding very often on the Jenkins instance. This adds retries to both those commands so that the machine has about 5 minutes of retrying before it gives up.

Note: these retries don't seem to be needed when I run from my Mac laptop.